### PR TITLE
메일 전송 시 발생하는 오류 해결

### DIFF
--- a/log-analysis-module/main.py
+++ b/log-analysis-module/main.py
@@ -97,7 +97,7 @@ def consume_loop(running_mode):
                             [preprocess(dict_data)])
                         result = clusteringMgr.predictNewData(scaled_data)
                         if result == 0:
-                            sendMail(message)
+                            sendMail(message.decode('utf-8'))
                         dict_data.update({'label': result})
                         print('predict done')
                         jsonformat = json.dumps(dict_data)


### PR DESCRIPTION
비정상 데이터 로그를 메일로 보낼떄 오류 발생
```
'bytes' object has no attribute 'encode' 
```
utf-8인코딩 문자를 unicode로 다시 decode하여 python에서 사용할수 있게 하여 해결
